### PR TITLE
IO updates

### DIFF
--- a/src/mads/build/logging.py
+++ b/src/mads/build/logging.py
@@ -167,7 +167,7 @@ def new_logger() -> BuildLogger:
         fmtstr = "%(message)s"
         handlers.append(RichHandler(console=console, show_level=False, show_path=False))
     else:
-        handlers.append(logging.StreamHandler(sys.stdout))
+        handlers.append(logging.StreamHandler(sys.stderr))
 
     fmt = logging.Formatter(fmt=fmtstr, datefmt="%H:%M:%S")
 

--- a/src/mads/environ/git.py
+++ b/src/mads/environ/git.py
@@ -6,13 +6,14 @@ from functools import cache
 
 from pydantic_settings import BaseSettings
 
-from mads.build.shell import shell
 
 NOT_GIT = {"message": "[This does not appear to be a git project]"}
 
 
 @cache
 def git_config_source() -> dict[str, str]:
+    from mads.build.shell import shell
+
     cwd = Path(".git")
 
     # If the git cache is populated, .git is actually a file pointing to the

--- a/src/mads/environ/resources.py
+++ b/src/mads/environ/resources.py
@@ -6,8 +6,6 @@ from subprocess import CalledProcessError
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-from mads.build import log, shell
-
 
 class Resources(BaseSettings):
     """Get information about the current system we're running in."""
@@ -38,6 +36,8 @@ class Resources(BaseSettings):
 
     def enable_swap(self):
         """Enable swap memory."""
+
+        from mads.build import log, shell
 
         if self.swap_memory > 0:
             log.info("Swap memory is already enabled.")


### PR DESCRIPTION
* Always log to stderr. Valid uses of the CLI will be watching for stdout and we don't want to pollute it with logs.
* Allow overriding stdout and stderr in shell functions. Sometimes we don't care about the output at all.
* Defer some imports to better enable individual tool use.